### PR TITLE
Corrected tvOS platform identifiers.

### DIFF
--- a/Sources/Xcodeproj/pbxproj().swift
+++ b/Sources/Xcodeproj/pbxproj().swift
@@ -200,7 +200,7 @@ public func pbxproj(srcroot: String, projectRoot: String, xcodeprojPath: String,
         let supportedPlatforms = [
             "macosx",
             "iphoneos", "iphonesimulator",
-            "tvos", "tvsimulator",
+            "appletvos", "appletvsimulator",
             "watchos", "watchsimulator"]
         print("SUPPORTED_PLATFORMS = \(supportedPlatforms.joined(separator: " "))")
 


### PR DESCRIPTION
I noticed that when building a project whose `.xcodeproj` was generated via SPM via Carthage, the build would fail with:

    Parse error: unexpected SDK key "tvos"

So I created a tvOS project right from Xcode itself and ran

    xcodebuild -project Foo.xcodeproj -target Foo -showBuildSettings | grep PLATFORMS

which returned this:

    SUPPORTED_PLATFORMS = appletvos appletvsimulator

So I replaced

    tvos tvsimulator

as found in `MyProject.xcodeproj/Configs/Project.xcconfig` with 

    appletvos appletvsimulator

and carthage now builds successfully.

FYI: GitHub [currently lists 48 projects](https://github.com/search?q=%22tvos+tvsimulator%22&ref=opensearch&type=Code) with this corrupt `.xcconfig` file.